### PR TITLE
Fix build failures by updating test imports and type assertions

### DIFF
--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ErrorBoundary } from './ErrorBoundary'
 

--- a/src/components/ui/TouchSlider.test.tsx
+++ b/src/components/ui/TouchSlider.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import { TouchSlider } from './TouchSlider'
 
@@ -25,7 +25,7 @@ describe('TouchSlider', () => {
     expect(slider).toHaveAttribute('step', '1')
     expect(slider).toHaveAttribute('value', '50')
     // Check inline style
-    expect(slider?.style.touchAction).toBe('none')
+    expect((slider as HTMLInputElement)?.style.touchAction).toBe('none')
   })
 
   it('should apply custom className', () => {

--- a/src/components/workspace/SafeImageDisplay.test.tsx
+++ b/src/components/workspace/SafeImageDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { SafeImageDisplay } from './SafeImageDisplay'
 import { useStore } from '../../store'

--- a/src/components/workspace/ZoomControls.test.tsx
+++ b/src/components/workspace/ZoomControls.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ZoomControls } from './ZoomControls'
 import { useStore } from '../../store'

--- a/src/filters/base/Filter.test.ts
+++ b/src/filters/base/Filter.test.ts
@@ -20,7 +20,7 @@ class TestFilter extends Filter {
     return [
       {
         id: 'intensity',
-        name: 'Intensity',
+        label: 'Intensity',
         type: 'slider',
         value: 50,
         min: 0,
@@ -29,7 +29,7 @@ class TestFilter extends Filter {
       },
       {
         id: 'mode',
-        name: 'Mode',
+        label: 'Mode',
         type: 'select',
         value: 'normal',
         options: [
@@ -41,7 +41,7 @@ class TestFilter extends Filter {
   }
   
   createFilter(): PixiFilter {
-    return new PixiFilter() as any
+    return new (PixiFilter as any)() as any
   }
   
   protected updateFilter(): void {


### PR DESCRIPTION
## Summary
- Fixes build failures caused by missing imports in test files
- Corrects type assertions in TouchSlider test
- Updates property names in Filter test for consistency

## Changes

### Test Files
- Added missing `beforeEach` and `afterEach` imports from `vitest` in multiple test files
- Corrected type assertion for `slider.style.touchAction` in `TouchSlider.test.tsx` to avoid type errors

### Filter Test
- Renamed `name` property to `label` in filter options for clarity
- Adjusted `createFilter` method to properly cast `PixiFilter` instance

## Test plan
- Verified all tests compile and run without errors
- Confirmed no regressions in test behavior after import and type assertion fixes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b9d23214-926c-496d-9344-47fa756649ca