### PR TITLE
Add Video Generation Modal for Video Morphing Preview

### DIFF
--- a/src/components/ui/VideoGenerationModal.tsx
+++ b/src/components/ui/VideoGenerationModal.tsx
@@ -1,0 +1,151 @@
+import React, { useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { X, Play, Pause, Download, RotateCcw } from 'lucide-react'
+
+interface VideoGenerationModalProps {
+  isOpen: boolean
+  onClose: () => void
+  videoFrames: { imageData: ImageData; timestamp: number }[]
+  currentFrame: number
+  isPlaying: boolean
+  onPlay: () => void
+  onPause: () => void
+  onReset: () => void
+  onFrameChange: (frame: number) => void
+  onExport: () => void
+  fps: number
+  width: number
+  height: number
+}
+
+export function VideoGenerationModal({
+  isOpen,
+  onClose,
+  videoFrames,
+  currentFrame,
+  isPlaying,
+  onPlay,
+  onPause,
+  onReset,
+  onFrameChange,
+  onExport,
+  fps,
+  width,
+  height
+}: VideoGenerationModalProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  
+  useEffect(() => {
+    if (!isOpen) return
+    
+    const canvas = canvasRef.current
+    if (!canvas || videoFrames.length === 0) return
+    
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    
+    const frame = videoFrames[currentFrame]
+    if (frame) {
+      ctx.putImageData(frame.imageData, 0, 0)
+    }
+  }, [currentFrame, videoFrames, isOpen])
+  
+  if (!isOpen) return null
+  
+  const duration = videoFrames.length / fps
+  const currentTime = currentFrame / fps
+  
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+            Video Preview
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            <X size={20} className="text-gray-500" />
+          </button>
+        </div>
+        
+        {/* Video canvas */}
+        <div className="flex-1 overflow-auto p-6 flex items-center justify-center bg-gray-50 dark:bg-gray-800">
+          <div className="relative">
+            <canvas
+              ref={canvasRef}
+              width={width}
+              height={height}
+              className="max-w-full h-auto rounded-lg shadow-lg"
+              style={{ maxHeight: 'calc(90vh - 300px)' }}
+            />
+          </div>
+        </div>
+        
+        {/* Controls */}
+        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 space-y-4">
+          {/* Progress bar */}
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+              <span>{currentTime.toFixed(1)}s</span>
+              <span>{duration.toFixed(1)}s</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={videoFrames.length - 1}
+              value={currentFrame}
+              onChange={(e) => onFrameChange(parseInt(e.target.value))}
+              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+            />
+          </div>
+          
+          {/* Control buttons */}
+          <div className="flex items-center justify-center gap-4">
+            <button
+              onClick={onReset}
+              className="p-3 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors"
+              title="Reset"
+            >
+              <RotateCcw size={20} />
+            </button>
+            
+            {isPlaying ? (
+              <button
+                onClick={onPause}
+                className="p-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+                title="Pause"
+              >
+                <Pause size={24} />
+              </button>
+            ) : (
+              <button
+                onClick={onPlay}
+                className="p-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+                title="Play"
+              >
+                <Play size={24} />
+              </button>
+            )}
+            
+            <button
+              onClick={onExport}
+              className="p-3 rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors"
+              title="Download"
+            >
+              <Download size={20} />
+            </button>
+          </div>
+          
+          {/* Info */}
+          <div className="text-center text-sm text-gray-600 dark:text-gray-400">
+            {videoFrames.length} frames at {fps} FPS
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/components/workspace/FeaturePointSelector.tsx
+++ b/src/components/workspace/FeaturePointSelector.tsx
@@ -21,9 +21,24 @@ export function FeaturePointSelector({
   const [nextPointSide, setNextPointSide] = useState<'source' | 'target'>('source')
   const [tempPoint, setTempPoint] = useState<Partial<FeaturePoint> | null>(null)
   const animationFrameRef = useRef<number>(0)
+  const [canvasesReady, setCanvasesReady] = useState(false)
+  
+  // Ensure canvases are properly sized when images change
+  useEffect(() => {
+    if (sourceImage && targetImage && sourceCanvasRef.current && targetCanvasRef.current) {
+      sourceCanvasRef.current.width = sourceImage.width
+      sourceCanvasRef.current.height = sourceImage.height
+      targetCanvasRef.current.width = targetImage.width
+      targetCanvasRef.current.height = targetImage.height
+      setCanvasesReady(true)
+    }
+  }, [sourceImage, targetImage])
   
   // Draw images and points with animation
   useEffect(() => {
+    // Ensure both images are loaded before drawing
+    if (!sourceImage || !targetImage || !canvasesReady) return
+    
     const isMobile = window.innerWidth < 768
     
     if (isMobile && (featurePoints.length > 0 || tempPoint)) {
@@ -42,13 +57,16 @@ export function FeaturePointSelector({
       drawCanvas('source')
       drawCanvas('target')
     }
-  }, [sourceImage, targetImage, featurePoints, selectedPointId, tempPoint])
+  }, [sourceImage, targetImage, featurePoints, selectedPointId, tempPoint, canvasesReady])
   
   const drawCanvas = (side: 'source' | 'target') => {
     const canvas = side === 'source' ? sourceCanvasRef.current : targetCanvasRef.current
     const image = side === 'source' ? sourceImage : targetImage
     
-    if (!canvas || !image) return
+    if (!canvas || !image) {
+      console.warn(`Missing ${side} canvas or image`, { canvas: !!canvas, image: !!image })
+      return
+    }
     
     const ctx = canvas.getContext('2d')!
     ctx.clearRect(0, 0, canvas.width, canvas.height)


### PR DESCRIPTION
## Summary
- Introduces a new `VideoGenerationModal` component for previewing generated morphing videos
- Enhances `MorphDisplay` to support video playback controls and modal display
- Improves canvas handling in `FeaturePointSelector` for better image and canvas synchronization

## Changes

### UI Components
- **VideoGenerationModal**: New modal component with video playback controls (play, pause, reset, export) and frame scrubbing
- Integrated `VideoGenerationModal` into `MorphDisplay` to show video preview after generation
- Removed old inline video canvas and controls in favor of modal-based preview

### FeaturePointSelector
- Added canvas resizing logic when source or target images change
- Added readiness state to ensure canvases are properly sized before drawing
- Added safety checks and warnings for missing canvas or image elements

### MorphDisplay
- Added state and handlers for video modal visibility, current frame, and playback
- Refactored video playback logic to update current frame without direct canvas drawing (delegated to modal)
- Added reset video functionality
- Connected modal export button to show download modal

## Test plan
- [x] Generate morphing video and verify video modal opens with correct frames
- [x] Test play, pause, reset, and frame scrubbing controls in video modal
- [x] Confirm video export triggers download modal
- [x] Verify feature point selector canvases resize correctly on image change
- [x] Check console for warnings related to canvas or image availability during drawing

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0e80be83-05c0-4a32-bcf3-f50c48da915b